### PR TITLE
Disable parameter services

### DIFF
--- a/src/robot_state_publisher.cpp
+++ b/src/robot_state_publisher.cpp
@@ -75,7 +75,10 @@ geometry_msgs::msg::TransformStamped kdlToTransform(const KDL::Frame & k)
 }  // namespace
 
 RobotStatePublisher::RobotStatePublisher(const rclcpp::NodeOptions & options)
-: rclcpp::Node("robot_state_publisher", options)
+: rclcpp::Node(
+    "robot_state_publisher",
+    rclcpp::NodeOptions(options).start_parameter_services(false)
+)
 {
   // get the XML
   std::string urdf_xml = this->declare_parameter("robot_description", std::string(""));


### PR DESCRIPTION
### Description

Disable ROS Node parameter services.

### Motivation and Context

Mitigate network strain because of DDS discovery over WiFi.

The following services are suppressed now:
- `~/describe_parameters`
- `~/get_parameter_types`
- `~/get_parameters`
- `~/list_parameters`
- `~/set_parameters`
- `~/set_parameters_atomically`

The services are not needed.

### How Has This Been Tested?

```bash
colcon build --packages-select robot_state_publisher
# ... (secret) launch command used by the project ...
ros2 service list
```

<br>
---

- [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/developer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).
- [Semantic Code Reviews](https://www.m31coding.com/blog/semantic-reviews.html) - Simple and direct comments without drama.
